### PR TITLE
fix: fill 0x00 lock witness for MNFT in buildCancelTx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omiga-dex",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "The JavaScript SDK for CKB DEX",
   "author": "duanyytop <duanyytop@gmail.com>",
   "license": "MIT",

--- a/src/order/cancel.ts
+++ b/src/order/cancel.ts
@@ -114,7 +114,13 @@ export const buildCancelTx = async ({
   const witnesses = inputs.map((_, index) => (index === orderInputs.length ? serializeWitnessArgs(emptyWitness) : '0x'))
   if (ckbAsset === CKBAsset.SPORE) {
     witnesses.push(sporeCoBuild)
+  } else if (ckbAsset === CKBAsset.MNFT) {
+    // MNFT must not be held and transferred by anyone-can-pay lock
+    orderInputs.forEach((_, index) => {
+      witnesses[index] = serializeWitnessArgs({ lock: '0x00', inputType: '', outputType: '' })
+    })
   }
+
   if (joyID && joyID.connectData.keyType === 'sub_key') {
     const pubkeyHash = append0x(blake160(append0x(joyID.connectData.pubkey), 'hex'))
     const req: SubkeyUnlockReq = {

--- a/src/order/helper.ts
+++ b/src/order/helper.ts
@@ -59,7 +59,7 @@ export const calculateEmptyCellMinCapacity = (lock: CKBComponents.Script): bigin
 
 export const calculateTransactionFee = (txSize: number): bigint => {
   const ratio = BigNumber(1000)
-  const defaultFeeRate = BigNumber(1100)
+  const defaultFeeRate = BigNumber(2000)
   const fee = BigNumber(txSize).multipliedBy(defaultFeeRate).div(ratio)
   return BigInt(fee.toFixed(0, BigNumber.ROUND_CEIL).toString())
 }


### PR DESCRIPTION
Fixed -302 Error, more info:
https://github.com/search?q=repo%3Anervina-labs%2Fckb-nft-scripts%20GroupInputWitnessNoneError&type=code